### PR TITLE
v0.1.1 migration prep

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -49,7 +49,7 @@ checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
 
 [[package]]
 name = "collectxyz"
-version = "0.1.0"
+version = "0.1.1"
 dependencies = [
  "cosmwasm-std",
  "cw721",
@@ -60,7 +60,7 @@ dependencies = [
 
 [[package]]
 name = "collectxyz-nft-contract"
-version = "0.1.0"
+version = "0.1.1"
 dependencies = [
  "base64",
  "collectxyz",

--- a/contracts/collectxyz-nft-contract/Cargo.toml
+++ b/contracts/collectxyz-nft-contract/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "collectxyz-nft-contract"
-version = "0.1.0"
+version = "0.1.1"
 authors = ["0xja <0xja@protonmail.com>"]
 edition = "2018"
 description = "The NFT smart contract powering xyz on Terra"

--- a/contracts/collectxyz-nft-contract/src/contract.rs
+++ b/contracts/collectxyz-nft-contract/src/contract.rs
@@ -1,8 +1,8 @@
 use collectxyz::nft::{ExecuteMsg, InstantiateMsg, MigrateMsg, QueryMsg};
 use cosmwasm_std::{
-    entry_point, to_binary, Binary, Deps, DepsMut, Env, MessageInfo, Response, StdResult,
+    entry_point, to_binary, Binary, Deps, DepsMut, Env, MessageInfo, Response, StdError, StdResult,
 };
-use cw2::set_contract_version;
+use cw2::{get_contract_version, set_contract_version};
 
 use crate::error::ContractError;
 use crate::execute as ExecHandler;
@@ -91,6 +91,14 @@ pub fn query(deps: Deps, env: Env, msg: QueryMsg) -> StdResult<Binary> {
 
 #[entry_point]
 pub fn migrate(deps: DepsMut, env: Env, msg: MigrateMsg) -> StdResult<Response> {
+    let version = get_contract_version(deps.storage)?;
+    if version.contract != CONTRACT_NAME {
+        return Err(StdError::generic_err(
+            "can't migrate to contract with different name",
+        ));
+    }
+
     set_contract_version(deps.storage, CONTRACT_NAME, CONTRACT_VERSION)?;
+
     ExecHandler::migrate(deps, env, msg)
 }

--- a/contracts/collectxyz-nft-contract/src/execute.rs
+++ b/contracts/collectxyz-nft-contract/src/execute.rs
@@ -284,7 +284,6 @@ pub fn cw721_base_execute(
         .map_err(|err| err.into())
 }
 
-pub fn migrate(deps: DepsMut, _env: Env, msg: MigrateMsg) -> StdResult<Response> {
-    CONFIG.save(deps.storage, &msg.config)?;
+pub fn migrate(_deps: DepsMut, _env: Env, _msg: MigrateMsg) -> StdResult<Response> {
     Ok(Response::default().add_attribute("action", "migrate"))
 }

--- a/packages/collectxyz/Cargo.toml
+++ b/packages/collectxyz/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "collectxyz"
-version = "0.1.0"
+version = "0.1.1"
 authors = ["0xja <0xja@protonmail.com>"]
 edition = "2018"
 description = "Common data types and helpers for interacting with xyz smart contracts"

--- a/packages/collectxyz/src/nft.rs
+++ b/packages/collectxyz/src/nft.rs
@@ -361,9 +361,6 @@ pub struct MoveParamsResponse {
     pub duration_nanos: u64,
 }
 
-/// This is a custom message type, not present in cw721-base
 #[derive(Serialize, Deserialize, Clone, PartialEq, JsonSchema, Debug)]
 #[serde(rename_all = "snake_case")]
-pub struct MigrateMsg {
-    pub config: Config,
-}
+pub struct MigrateMsg {}


### PR DESCRIPTION
This PR updates `MigrateMsg` to contain no data, and removes code from the migration handler that would update the contract config (was in place to simplify fast iteration during initial contract development).

The code on this branch has been built and deployed to the testnet. If we find no issues in manual testing against the testnet contract, we should feel secure migrating the mainnet contract to v0.1.1.