### PR TITLE
fix: emit token ids on mutation

### DIFF
--- a/contracts/collectxyz-nft-contract/src/contract_tests.rs
+++ b/contracts/collectxyz-nft-contract/src/contract_tests.rs
@@ -137,7 +137,7 @@ fn minting() {
     assert_eq!(err, ContractError::Unauthorized {});
 
     // nonowner with valid signature can mint
-    let _ = execute(
+    let res = execute(
         deps.as_mut(),
         mock_env(),
         mock_info(NONOWNER, &[]),
@@ -147,6 +147,12 @@ fn minting() {
         },
     )
     .unwrap();
+
+    // ensure response event emits the minted token_id
+    assert!(res
+        .attributes
+        .iter()
+        .any(|attr| attr.key == "token_id" && attr.value == "xyz #1"));
 
     // random cannot mint a token with same coordinates twice
     let err = execute(
@@ -759,7 +765,7 @@ fn move_token() {
     println!("{:#?}", move_params);
 
     // nonowner can move with sufficient move fee paid
-    let _ = execute(
+    let res = execute(
         deps.as_mut(),
         mock_env(),
         mock_info(NONOWNER, &[move_params.fee.clone()]),
@@ -769,6 +775,12 @@ fn move_token() {
         },
     )
     .unwrap();
+
+    // ensure response event emits the moved token_id
+    assert!(res
+        .attributes
+        .iter()
+        .any(|attr| attr.key == "token_id" && attr.value == "xyz #1"));
 
     // look up the updated token
     let res = QueryHandler::query_xyz_nft_info(deps.as_ref(), nonowner_xyz_id.to_string()).unwrap();

--- a/contracts/collectxyz-nft-contract/src/execute.rs
+++ b/contracts/collectxyz-nft-contract/src/execute.rs
@@ -93,7 +93,8 @@ pub fn execute_mint(
 
     Ok(Response::new()
         .add_attribute("action", "mint")
-        .add_attribute("minter", info.sender))
+        .add_attribute("minter", info.sender)
+        .add_attribute("token_id", token_id))
 }
 
 fn check_sufficient_funds(funds: Vec<Coin>, required: Coin) -> Result<(), ContractError> {
@@ -222,7 +223,8 @@ pub fn execute_move(
 
     Ok(Response::default()
         .add_attribute("action", "move")
-        .add_attribute("mover", info.sender))
+        .add_attribute("mover", info.sender)
+        .add_attribute("token_id", token_id))
 }
 
 pub fn execute_update_config(


### PR DESCRIPTION
This change allows projects that cache xyz token info to update their cache when a token mutation event is emitted.