### PR TITLE
update token metadata format in query responses

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -49,7 +49,7 @@ checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
 
 [[package]]
 name = "collectxyz"
-version = "0.1.1"
+version = "0.2.0"
 dependencies = [
  "cosmwasm-std",
  "cw721",
@@ -60,7 +60,7 @@ dependencies = [
 
 [[package]]
 name = "collectxyz-nft-contract"
-version = "0.1.1"
+version = "0.2.0"
 dependencies = [
  "base64",
  "collectxyz",

--- a/contracts/collectxyz-nft-contract/Cargo.toml
+++ b/contracts/collectxyz-nft-contract/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "collectxyz-nft-contract"
-version = "0.1.1"
+version = "0.2.0"
 authors = ["0xja <0xja@protonmail.com>"]
 edition = "2018"
 description = "The NFT smart contract powering xyz on Terra"
@@ -28,8 +28,8 @@ cosmwasm-storage = { version = "0.16.0" }
 cw-storage-plus = "0.9.1"
 cw0 = { version = "0.9.1" }
 cw2 = { version = "0.9.1" }
-cw721 = { version = "0.9.1" }
-cw721-base = { version = "0.9.1", features = ["library"] }
+cw721 = { version = "=0.9.1" }
+cw721-base = { version = "=0.9.1", features = ["library"] }
 thiserror = "1.0.29"
 rsa = { version = "0.5.0" }
 getrandom = { version = "0.2.3" }
@@ -37,7 +37,7 @@ schemars = "0.8.3"
 sha2 = { version = "0.9.8" }
 serde = { version = "1.0.127", default-features = false, features = ["derive"] }
 serde_json = "1.0.67"
-collectxyz = { path = "../../packages/collectxyz", version = "0.1.0" }
+collectxyz = { path = "../../packages/collectxyz", version = "0.2.0" }
 
 [dev-dependencies]
 cosmwasm-schema = { version = "0.16.0" }

--- a/contracts/collectxyz-nft-contract/schema/xyz_tokens_response.json
+++ b/contracts/collectxyz-nft-contract/schema/xyz_tokens_response.json
@@ -9,7 +9,7 @@
     "tokens": {
       "type": "array",
       "items": {
-        "$ref": "#/definitions/TokenInfo_for_XyzExtension"
+        "$ref": "#/definitions/XyzTokenInfo"
       }
     }
   },
@@ -119,56 +119,6 @@
         }
       ]
     },
-    "TokenInfo_for_XyzExtension": {
-      "type": "object",
-      "required": [
-        "approvals",
-        "description",
-        "extension",
-        "name",
-        "owner"
-      ],
-      "properties": {
-        "approvals": {
-          "description": "Approvals are stored here, as we clear them all upon transfer and cannot accumulate much",
-          "type": "array",
-          "items": {
-            "$ref": "#/definitions/Approval"
-          }
-        },
-        "description": {
-          "description": "Describes the asset to which this NFT represents",
-          "type": "string"
-        },
-        "extension": {
-          "description": "You can add any custom metadata here when you extend cw721-base",
-          "allOf": [
-            {
-              "$ref": "#/definitions/XyzExtension"
-            }
-          ]
-        },
-        "image": {
-          "description": "A URI pointing to an image representing the asset",
-          "type": [
-            "string",
-            "null"
-          ]
-        },
-        "name": {
-          "description": "Identifies the asset to which this NFT represents",
-          "type": "string"
-        },
-        "owner": {
-          "description": "The owner of the newly minted NFT",
-          "allOf": [
-            {
-              "$ref": "#/definitions/Addr"
-            }
-          ]
-        }
-      }
-    },
     "Uint64": {
       "description": "A thin wrapper around u64 that is using strings for JSON encoding/decoding, such that the full u64 range can be used for clients that convert JSON numbers to floats, like JavaScript and jq.\n\n# Examples\n\nUse `from` to create instances of this and `u64` to get the value out:\n\n``` # use cosmwasm_std::Uint64; let a = Uint64::from(42u64); assert_eq!(a.u64(), 42);\n\nlet b = Uint64::from(70u32); assert_eq!(b.u64(), 70); ```",
       "type": "string"
@@ -195,6 +145,42 @@
               "type": "null"
             }
           ]
+        }
+      }
+    },
+    "XyzTokenInfo": {
+      "type": "object",
+      "required": [
+        "approvals",
+        "description",
+        "extension",
+        "name",
+        "owner"
+      ],
+      "properties": {
+        "approvals": {
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/Approval"
+          }
+        },
+        "description": {
+          "type": "string"
+        },
+        "extension": {
+          "$ref": "#/definitions/XyzExtension"
+        },
+        "image": {
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "name": {
+          "type": "string"
+        },
+        "owner": {
+          "$ref": "#/definitions/Addr"
         }
       }
     }

--- a/contracts/collectxyz-nft-contract/src/contract_tests.rs
+++ b/contracts/collectxyz-nft-contract/src/contract_tests.rs
@@ -225,12 +225,12 @@ fn minting() {
         )
         .unwrap(),
     );
-    assert_eq!(info["name"], "xyz #1");
+    assert_eq!(info["extension"]["name"], "xyz #1");
     assert_eq!(
-        info["description"],
+        info["extension"]["description"],
         "Explore the metaverse, starting with xyz."
     );
-    if let serde_json::Value::String(image) = &info["image"] {
+    if let serde_json::Value::String(image) = &info["extension"]["image"] {
         assert!(image.starts_with("data:image/svg+xml;base64,"));
     } else {
         panic!("NftInfo response 'image' had wrong data type");
@@ -674,9 +674,7 @@ fn move_token() {
     .unwrap_err();
     assert_eq!(
         err,
-        ContractError::Std(StdError::not_found(
-            "cw721_base::state::TokenInfo<collectxyz::nft::XyzExtension>"
-        ))
+        ContractError::Std(StdError::not_found("collectxyz::nft::XyzTokenInfo"))
     );
 
     // can't move a token that isn't yours

--- a/contracts/collectxyz-nft-contract/src/execute.rs
+++ b/contracts/collectxyz-nft-contract/src/execute.rs
@@ -3,12 +3,14 @@ use rsa::{hash::Hash, padding::PaddingScheme, PublicKey};
 use serde_json;
 use sha2::{Digest, Sha256};
 
-use collectxyz::nft::{Config, Coordinates, ExecuteMsg, InstantiateMsg, MigrateMsg, XyzExtension};
+use collectxyz::nft::{
+    Config, Coordinates, ExecuteMsg, InstantiateMsg, MigrateMsg, XyzExtension, XyzTokenInfo,
+};
 use cosmwasm_std::{
     BankMsg, Coin, DepsMut, Empty, Env, MessageInfo, Order, Response, StdError, StdResult, Storage,
 };
 use cw721::ContractInfoResponse;
-use cw721_base::{state::TokenInfo, Cw721Contract};
+use cw721_base::Cw721Contract;
 
 use crate::error::ContractError;
 use crate::state::{load_captcha_public_key, save_captcha_public_key, tokens, CONFIG, OWNER};
@@ -72,7 +74,7 @@ pub fn execute_mint(
     // create the token
     let num_tokens = 1 + num_tokens;
     let token_id = format!("xyz #{}", &num_tokens);
-    let token = TokenInfo::<XyzExtension> {
+    let token = XyzTokenInfo {
         owner: info.sender.clone(),
         approvals: vec![],
         name: token_id.clone(),

--- a/contracts/collectxyz-nft-contract/src/query.rs
+++ b/contracts/collectxyz-nft-contract/src/query.rs
@@ -131,10 +131,7 @@ pub fn cw721_base_query(deps: Deps, env: Env, msg: QueryMsg) -> StdResult<Binary
 
 pub fn query_nft_info(deps: Deps, _env: Env, token_id: String) -> StdResult<Cw721NftInfoResponse> {
     let info = tokens().load(deps.storage, &token_id)?;
-    Ok(Cw721NftInfoResponse {
-        token_uri: None,
-        extension: info.as_cw721_metadata(),
-    })
+    Ok(info.as_cw721_nft_info())
 }
 
 pub fn query_all_nft_info(
@@ -149,10 +146,7 @@ pub fn query_all_nft_info(
             owner: info.owner.to_string(),
             approvals: humanize_approvals(&env.block, &info, include_expired),
         },
-        info: Cw721NftInfoResponse {
-            token_uri: None,
-            extension: info.as_cw721_metadata(),
-        },
+        info: info.as_cw721_nft_info(),
     })
 }
 

--- a/packages/collectxyz/Cargo.toml
+++ b/packages/collectxyz/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "collectxyz"
-version = "0.1.1"
+version = "0.2.0"
 authors = ["0xja <0xja@protonmail.com>"]
 edition = "2018"
 description = "Common data types and helpers for interacting with xyz smart contracts"

--- a/packages/collectxyz/src/nft.rs
+++ b/packages/collectxyz/src/nft.rs
@@ -179,17 +179,20 @@ pub struct XyzTokenInfo {
 }
 
 impl XyzTokenInfo {
-    pub fn as_cw721_metadata(&self) -> Cw721Metadata {
-        Cw721Metadata {
-            name: Some(self.name.clone()),
-            image: self.image.clone(),
-            description: Some(self.description.clone()),
-            attributes: Some(self.extension.as_traits()),
-            image_data: None,
-            external_url: None,
-            animation_url: None,
-            background_color: None,
-            youtube_url: None,
+    pub fn as_cw721_nft_info(&self) -> Cw721NftInfoResponse {
+        Cw721NftInfoResponse {
+            token_uri: None,
+            extension: Cw721Metadata {
+                name: Some(self.name.clone()),
+                image: self.image.clone(),
+                description: Some(self.description.clone()),
+                attributes: Some(self.extension.as_traits()),
+                image_data: None,
+                external_url: None,
+                animation_url: None,
+                background_color: None,
+                youtube_url: None,
+            },
         }
     }
 }
@@ -457,7 +460,7 @@ mod tests {
     use super::*;
 
     #[test]
-    fn xyz_token_info_as_cw721_metadata() {
+    fn xyz_token_info_as_cw721_nft_info() {
         let info = XyzTokenInfo {
             name: "xyz #1".to_string(),
             owner: Addr::unchecked("test owner"),
@@ -472,33 +475,36 @@ mod tests {
         };
 
         assert_eq!(
-            info.as_cw721_metadata(),
-            Cw721Metadata {
-                name: Some("xyz #1".to_string()),
-                description: Some("test description".to_string()),
-                image: Some("test image".to_string()),
-                attributes: Some(vec![
-                    Cw721Trait {
-                        display_type: None,
-                        trait_type: "x".to_string(),
-                        value: "1".to_string(),
-                    },
-                    Cw721Trait {
-                        display_type: None,
-                        trait_type: "y".to_string(),
-                        value: "2".to_string(),
-                    },
-                    Cw721Trait {
-                        display_type: None,
-                        trait_type: "z".to_string(),
-                        value: "3".to_string(),
-                    },
-                ]),
-                image_data: None,
-                animation_url: None,
-                youtube_url: None,
-                external_url: None,
-                background_color: None
+            info.as_cw721_nft_info(),
+            Cw721NftInfoResponse {
+                token_uri: None,
+                extension: Cw721Metadata {
+                    name: Some("xyz #1".to_string()),
+                    description: Some("test description".to_string()),
+                    image: Some("test image".to_string()),
+                    attributes: Some(vec![
+                        Cw721Trait {
+                            display_type: None,
+                            trait_type: "x".to_string(),
+                            value: "1".to_string(),
+                        },
+                        Cw721Trait {
+                            display_type: None,
+                            trait_type: "y".to_string(),
+                            value: "2".to_string(),
+                        },
+                        Cw721Trait {
+                            display_type: None,
+                            trait_type: "z".to_string(),
+                            value: "3".to_string(),
+                        },
+                    ]),
+                    image_data: None,
+                    animation_url: None,
+                    youtube_url: None,
+                    external_url: None,
+                    background_color: None
+                }
             }
         )
     }


### PR DESCRIPTION
This PR updates the NFT contract's `nft_info` and `all_nft_info` query responses to adhere to [OpenSea metadata standards](https://docs.opensea.io/docs/metadata-standards). These changes should make our NFT contract behave like a cw721 v0.9.2 contract, even though we still need to use v0.9.1 under the hood because of how our tokens are represented in the contract storage (at least for now).

Without these updates, `nft_info` returns token metadata that looks like:
```
{
  "name": "xyz #1",
  "description": "Explore the metaverse, starting with xyz.",
  "image": "data:image/svg+xml;base64,...",
  "extension": {
    "coordinates": {
      "x": 0,
      "y": 0,
      "z": 0
    },
    "prev_coordinates": null,
    "arrival": "123456..."
  }
}
```

With these updates, `nft_info` returns token metadata that looks like:
```
{
  "token_uri": null,
  "extension": {
    "name": "xyz #1",
    "description": "xyz is a...",
    "attributes": [
      {
        "display_type": null,
        "trait_type": "x",
        "value": "0"
      },
      {
        "display_type": null,
        "trait_type": "y",
        "value": "0"
      },
      {
        "display_type": null,
        "trait_type": "z",
        "value": "0"
      }
    ],
    "image": "data:image/svg+xml;base64,...",
    "image_data": null,
    "external_url": null,
    "background_color": null,
    "animation_url": null,
    "youtube_url": null
  }
}
```

Note: this doesn't change the response format for any non-CW721 query methods, like `xyz_nft_info`.