### PR TITLE
fix: use same start_after for all vs owner xyz query

### DIFF
--- a/Developing.md
+++ b/Developing.md
@@ -23,6 +23,7 @@ rustup target add wasm32-unknown-unknown
 ```
 
 ## Linting
+
 The following commands should be run for linting/formatting (and are enforced by CI):
 ```
 cargo clippy --all --all-targets -- -D warnings

--- a/Developing.md
+++ b/Developing.md
@@ -22,6 +22,13 @@ rustup target list --installed
 rustup target add wasm32-unknown-unknown
 ```
 
+## Linting
+The following commands should be run for linting/formatting (and are enforced by CI):
+```
+cargo clippy --all --all-targets -- -D warnings
+cargo fmt -- --check
+```
+
 ## Compiling and running tests
 
 Now that you created your custom contract, make sure you can compile and run it before

--- a/contracts/collectxyz-nft-contract/src/contract_tests.rs
+++ b/contracts/collectxyz-nft-contract/src/contract_tests.rs
@@ -890,7 +890,7 @@ fn all_xyz_tokens() {
     let mut deps = mock_dependencies(&[]);
     setup_contract(deps.as_mut(), None, None, None);
 
-    // throws error on coordinate with no nft
+    // check no tokens returned
     let res = as_json(
         &query(
             deps.as_ref(),
@@ -928,6 +928,7 @@ fn all_xyz_tokens() {
     )
     .unwrap();
 
+    // check both tokens returned
     let res = as_json(
         &query(
             deps.as_ref(),
@@ -942,6 +943,7 @@ fn all_xyz_tokens() {
     assert_eq!(res["tokens"][0]["name"], "xyz #1");
     assert_eq!(res["tokens"][1]["name"], "xyz #2");
 
+    // check only second token returned
     let res = as_json(
         &query(
             deps.as_ref(),

--- a/contracts/collectxyz-nft-contract/src/contract_tests.rs
+++ b/contracts/collectxyz-nft-contract/src/contract_tests.rs
@@ -4,7 +4,7 @@ use std::str;
 use collectxyz::nft::{Config, Coordinates, ExecuteMsg, InstantiateMsg, QueryMsg, XyzExtension};
 use cosmwasm_std::testing::{mock_dependencies, mock_env, mock_info};
 use cosmwasm_std::{BankMsg, Binary, Coin, DepsMut, StdError, Uint128};
-use serde_json::{json};
+use serde_json::json;
 
 use crate::contract::{execute, instantiate, query};
 use crate::error::ContractError;

--- a/contracts/collectxyz-nft-contract/src/contract_tests.rs
+++ b/contracts/collectxyz-nft-contract/src/contract_tests.rs
@@ -4,7 +4,7 @@ use std::str;
 use collectxyz::nft::{Config, Coordinates, ExecuteMsg, InstantiateMsg, QueryMsg, XyzExtension};
 use cosmwasm_std::testing::{mock_dependencies, mock_env, mock_info};
 use cosmwasm_std::{BankMsg, Binary, Coin, DepsMut, StdError, Uint128};
-use serde_json::{Number, Value, json};
+use serde_json::{json};
 
 use crate::contract::{execute, instantiate, query};
 use crate::error::ContractError;

--- a/contracts/collectxyz-nft-contract/src/contract_tests.rs
+++ b/contracts/collectxyz-nft-contract/src/contract_tests.rs
@@ -4,6 +4,7 @@ use std::str;
 use collectxyz::nft::{Config, Coordinates, ExecuteMsg, InstantiateMsg, QueryMsg, XyzExtension};
 use cosmwasm_std::testing::{mock_dependencies, mock_env, mock_info};
 use cosmwasm_std::{BankMsg, Binary, Coin, DepsMut, StdError, Uint128};
+use serde_json::{Number, Value, json};
 
 use crate::contract::{execute, instantiate, query};
 use crate::error::ContractError;
@@ -882,4 +883,75 @@ fn xyz_nft_info_by_coords() {
     );
     assert_eq!(res["name"], "xyz #1");
     assert_eq!(res["owner"], NONOWNER);
+}
+
+#[test]
+fn all_xyz_tokens() {
+    let mut deps = mock_dependencies(&[]);
+    setup_contract(deps.as_mut(), None, None, None);
+
+    // throws error on coordinate with no nft
+    let res = as_json(
+        &query(
+            deps.as_ref(),
+            mock_env(),
+            QueryMsg::AllXyzTokens {
+                limit: Some(1),
+                start_after: None,
+            },
+        )
+        .unwrap(),
+    );
+    assert_eq!(res, json!({ "tokens": [] }));
+
+    // mint the associated nft
+    let _ = execute(
+        deps.as_mut(),
+        mock_env(),
+        mock_info(NONOWNER, &[]),
+        ExecuteMsg::Mint {
+            captcha_signature: String::from(SIG_X0Y0Z0),
+            coordinates: Coordinates { x: 0, y: 0, z: 0 },
+        },
+    )
+    .unwrap();
+
+    // mint the associated nft
+    let _ = execute(
+        deps.as_mut(),
+        mock_env(),
+        mock_info(NONOWNER, &[]),
+        ExecuteMsg::Mint {
+            captcha_signature: String::from(SIG_X1Y1Z1),
+            coordinates: Coordinates { x: 1, y: 1, z: 1 },
+        },
+    )
+    .unwrap();
+
+    let res = as_json(
+        &query(
+            deps.as_ref(),
+            mock_env(),
+            QueryMsg::AllXyzTokens {
+                limit: Some(2),
+                start_after: None,
+            },
+        )
+        .unwrap(),
+    );
+    assert_eq!(res["tokens"][0]["name"], "xyz #1");
+    assert_eq!(res["tokens"][1]["name"], "xyz #2");
+
+    let res = as_json(
+        &query(
+            deps.as_ref(),
+            mock_env(),
+            QueryMsg::AllXyzTokens {
+                limit: Some(2),
+                start_after: Some("xyz #1".to_string()),
+            },
+        )
+        .unwrap(),
+    );
+    assert_eq!(res["tokens"][0]["name"], "xyz #2");
 }

--- a/contracts/collectxyz-nft-contract/src/query.rs
+++ b/contracts/collectxyz-nft-contract/src/query.rs
@@ -6,7 +6,6 @@ use collectxyz::nft::{
     XyzTokensResponse,
 };
 use cosmwasm_std::{to_binary, Binary, BlockInfo, Deps, Empty, Env, Order, StdError, StdResult};
-use cw0::maybe_addr;
 use cw721::{NumTokensResponse, OwnerOfResponse, TokensResponse};
 use cw721_base::{msg::QueryMsg as Cw721QueryMsg, Cw721Contract};
 use cw_storage_plus::Bound;
@@ -73,8 +72,7 @@ pub fn query_all_xyz_tokens(
     limit: Option<u32>,
 ) -> StdResult<XyzTokensResponse> {
     let limit = limit.unwrap_or(DEFAULT_LIMIT).min(MAX_LIMIT) as usize;
-    let start_addr = maybe_addr(deps.api, start_after)?;
-    let start = start_addr.map(|addr| Bound::exclusive(addr.as_ref()));
+    let start = start_after.map(Bound::exclusive);
 
     let tokens: StdResult<Vec<_>> = tokens()
         .range(deps.storage, start, None, Order::Ascending)


### PR DESCRIPTION
start_after parameter should be an id, same as with cw721 base methods